### PR TITLE
add max buckets quota

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,37 +1,15 @@
-name: Main
+name: Build Container Image
 
 on:
   push:
-  pull_request:
-    branches: [ main ]
+    branches:
+      - main
+    tags:
+      - 'v*'
 
 jobs:
-  lint:
-    name: lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.20'
-          cache: false
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
-          args: --timeout 5m
-
-  test:
-    name: test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: run tests using make
-        run: make test
-
   docker:
     name: docker
-    if: startsWith(github.event.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     needs:
       - lint

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,31 @@
+name: Main
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          cache: false
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout 5m
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: run tests using make
+        run: make test

--- a/api/v1alpha1/s3user_types.go
+++ b/api/v1alpha1/s3user_types.go
@@ -45,6 +45,7 @@ type S3UserStatus struct {
 // +kubebuilder:printcolumn:name="CLAIM NAME",type=string,JSONPath=`.spec.claimRef.name`
 // +kubebuilder:printcolumn:name="MAX OBJECTS",type=string,JSONPath=`.spec.quota.maxObjects`
 // +kubebuilder:printcolumn:name="MAX SIZE",type=string,JSONPath=`.spec.quota.maxSize`
+// +kubebuilder:printcolumn:name="MAX BUCKETS",type=string,JSONPath=`.spec.quota.maxBuckets`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=`.metadata.creationTimestamp`
 
 type S3User struct {

--- a/api/v1alpha1/s3userclaim_types.go
+++ b/api/v1alpha1/s3userclaim_types.go
@@ -32,7 +32,7 @@ type S3UserClaimSpec struct {
 	AdminSecret string `json:"adminSecret"`
 
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:={"maxSize":"1000", "maxObjects":"5368709120"}
+	// +kubebuilder:default:={"maxSize":"1000", "maxObjects":"5368709120", "maxBuckets": 2}
 	Quota *UserQuota `json:"quota,omitempty"`
 }
 
@@ -51,6 +51,7 @@ type S3UserClaimStatus struct {
 // +kubebuilder:printcolumn:name="S3USER",type=string,JSONPath=`.status.s3UserName`
 // +kubebuilder:printcolumn:name="MAX OBJECTS",type=string,JSONPath=`.status.quota.maxObjects`
 // +kubebuilder:printcolumn:name="MAX SIZE",type=string,JSONPath=`.status.quota.maxSize`
+// +kubebuilder:printcolumn:name="MAX BUCKETS",type=string,JSONPath=`.status.quota.maxBuckets`
 // +kubebuilder:printcolumn:name="AGE",type=date,JSONPath=`.metadata.creationTimestamp`
 
 type S3UserClaim struct {

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -8,4 +8,6 @@ type UserQuota struct {
 	MaxSize resource.Quantity `json:"maxSize,omitempty"`
 	// max number of objects the user can store
 	MaxObjects resource.Quantity `json:"maxObjects,omitempty"`
+	// max number of buckets the user can create
+	MaxBuckets int `json:"maxBuckets,omitempty"`
 }

--- a/config/crd/bases/s3.snappcloud.io_s3userclaims.yaml
+++ b/config/crd/bases/s3.snappcloud.io_s3userclaims.yaml
@@ -28,6 +28,9 @@ spec:
     - jsonPath: .status.quota.maxSize
       name: MAX SIZE
       type: string
+    - jsonPath: .status.quota.maxBuckets
+      name: MAX BUCKETS
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
@@ -54,10 +57,14 @@ spec:
                 type: string
               quota:
                 default:
+                  maxBuckets: 2
                   maxObjects: "5368709120"
                   maxSize: "1000"
                 description: UserQuota specifies the quota for a user in Ceph
                 properties:
+                  maxBuckets:
+                    description: max number of buckets the user can create
+                    type: integer
                   maxObjects:
                     anyOf:
                     - type: integer
@@ -87,6 +94,9 @@ spec:
               quota:
                 description: UserQuota specifies the quota for a user in Ceph
                 properties:
+                  maxBuckets:
+                    description: max number of buckets the user can create
+                    type: integer
                   maxObjects:
                     anyOf:
                     - type: integer

--- a/config/crd/bases/s3.snappcloud.io_s3users.yaml
+++ b/config/crd/bases/s3.snappcloud.io_s3users.yaml
@@ -31,6 +31,9 @@ spec:
     - jsonPath: .spec.quota.maxSize
       name: MAX SIZE
       type: string
+    - jsonPath: .spec.quota.maxBuckets
+      name: MAX BUCKETS
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
@@ -116,6 +119,9 @@ spec:
               quota:
                 description: UserQuota specifies the quota for a user in Ceph
                 properties:
+                  maxBuckets:
+                    description: max number of buckets the user can create
+                    type: integer
                   maxObjects:
                     anyOf:
                     - type: integer

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -3,7 +3,7 @@
 # It should be run by config/default
 resources:
 - bases/s3.snappcloud.io_s3userclaims.yaml
-#- bases/s3.snappcloud.io_s3users.yaml
+- bases/s3.snappcloud.io_s3users.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/samples/s3_v1alpha1_s3userclaim.yaml
+++ b/config/samples/s3_v1alpha1_s3userclaim.yaml
@@ -10,3 +10,4 @@ spec:
   quota:
     maxSize: 1000
     maxObjects: 1000
+    maxBuckets: 5

--- a/internal/controllers/s3userclaim/s3userclaim_test.go
+++ b/internal/controllers/s3userclaim/s3userclaim_test.go
@@ -49,6 +49,7 @@ var _ = Describe("S3UserClaim Controller", func() {
 		s3UserName          = fmt.Sprintf("%s.%s", s3UserClaimNamespace, s3UserClaimName)
 		quotaMaxSize        = resource.MustParse("3k")
 		quotaMaxObjects     = resource.MustParse("4M")
+		quotaMaxBuckets     = 20
 		cfg                 = config.DefaultConfig
 		ctx                 = context.Background()
 		k8sNameSpecialChars = regexp.MustCompile(`[.-]`)
@@ -83,6 +84,7 @@ var _ = Describe("S3UserClaim Controller", func() {
 				Quota: &s3v1alpha1.UserQuota{
 					MaxSize:    quotaMaxSize,
 					MaxObjects: quotaMaxObjects,
+					MaxBuckets: quotaMaxBuckets,
 				},
 			},
 		}
@@ -160,6 +162,7 @@ var _ = Describe("S3UserClaim Controller", func() {
 				g.Expect(gotUser.UserQuota.MaxObjects).NotTo(BeNil())
 				g.Expect(*gotUser.UserQuota.MaxSize).To(Equal(quotaMaxSize.Value()))
 				g.Expect(*gotUser.UserQuota.MaxObjects).To(Equal(quotaMaxObjects.Value()))
+				g.Expect(*gotUser.MaxBuckets).To(Equal(quotaMaxBuckets))
 			}).Should(Succeed())
 		})
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -7,6 +7,7 @@ const (
 
 	ResourceNameS3MaxObjects v1.ResourceName = "s3/objects"
 	ResourceNameS3MaxSize    v1.ResourceName = "s3/size"
+	ResourceNameS3MaxBuckets v1.ResourceName = "s3/buckets"
 
 	QuotaTypeUser = "user"
 


### PR DESCRIPTION
This PR adds the ability to set max-buckets value in the S3UserClaim resource. This max-buckets value is also validated against the cluster and namespace quota values.