### PR TITLE
Add/e2e test

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -29,3 +29,18 @@ jobs:
       - uses: actions/checkout@v3
       - name: run tests using make
         run: make test
+
+  e2e-test:
+    name: e2e-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: checkout code
+      - name: Install kuttl
+        run: |
+          curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64 -o /usr/local/bin/kuttl
+          chmod +x /usr/local/bin/kuttl
+      - name: Run e2e test
+        run: |
+          kuttl test
+

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -43,5 +43,6 @@ jobs:
       - name: Run e2e test
         run: kuttl test
       - name: Test teardown
-        run: make teardown-dev-env
-
+        run: |
+          make teardown-dev-env
+          make teardown-operator

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -41,6 +41,7 @@ jobs:
           curl -L https://github.com/kudobuilder/kuttl/releases/download/v0.15.0/kubectl-kuttl_0.15.0_linux_x86_64 -o /usr/local/bin/kuttl
           chmod +x /usr/local/bin/kuttl
       - name: Run e2e test
-        run: |
-          kuttl test
+        run: kuttl test
+      - name: Test teardown
+        run: make teardown-dev-env
 

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ vendor/
 testing/go*.tar.gz
 # Container id files of dev env containers
 testing/.run.*
+
+# KIND
+kind-logs*
+
+# Kubeconfig
+kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -285,6 +285,13 @@ setup-dev-env:
 teardown-dev-env:
 	docker rm -f test_ceph_a
 	docker network rm test_ceph_net
+	@if pgrep -x "main" > /dev/null; then \
+		echo "Killing the 'main' process..."; \
+		kill `pgrep main`; \
+	else \
+		echo "The 'main' process is not running."; \
+	fi
+
 
 ######################### Helmify
 HELMIFY ?= $(LOCALBIN)/helmify

--- a/Makefile
+++ b/Makefile
@@ -285,14 +285,16 @@ setup-dev-env:
 teardown-dev-env:
 	docker rm -f test_ceph_a
 	docker network rm test_ceph_net
+
+# Teardown the operator in case of running: make run
+.PHONY: teardown-operator
+teardown-operator:
 	@if pgrep -x "main" > /dev/null; then \
 		echo "Killing the 'main' process..."; \
 		kill `pgrep main`; \
 	else \
 		echo "The 'main' process is not running."; \
 	fi
-
-
 ######################### Helmify
 HELMIFY ?= $(LOCALBIN)/helmify
 

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:v1.23.3
+

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -1,0 +1,10 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestSuite
+startKIND: true
+kindConfig: "./kind-config.yaml"
+crdDir: "./config/crd/bases"
+testDirs:
+- "./testing/"
+# parallel: 3
+timeout: 300
+

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -6,5 +6,5 @@ crdDir: "./config/crd/bases"
 testDirs:
 - "./testing/"
 # parallel: 3
-timeout: 120
+timeout: 300
 

--- a/kuttl-test.yaml
+++ b/kuttl-test.yaml
@@ -6,5 +6,5 @@ crdDir: "./config/crd/bases"
 testDirs:
 - "./testing/"
 # parallel: 3
-timeout: 300
+timeout: 120
 

--- a/testing/e2e/00-install-ceph-operator.yaml
+++ b/testing/e2e/00-install-ceph-operator.yaml
@@ -1,0 +1,17 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  # Apply clusrter resource quota crd
+  - command: kubectl apply -f ../../config/external-crd
+  # Setup local ceph cluster as a docker container on host
+  - command: make -C ../../ setup-dev-env
+  # Run the s3-operator on localhost on port 8000 in the background
+  - command: make -C ../../ run
+    background: true
+  - command: kubectl create namespace s3-test
+  # The namespace should have the team label for the cluster resource quota
+  - command: kubectl label namespace s3-test snappcloud.io/team=myteam
+  # Wait till the s3-operator is up
+  - command: sleep 10
+
+

--- a/testing/e2e/00-install-ceph.yaml
+++ b/testing/e2e/00-install-ceph.yaml
@@ -1,6 +1,0 @@
-apiVersion: kuttl.dev/v1beta1
-kind: TestStep
-commands:
-  - command: make -C ../../ setup-dev-env 
-  - command: make -C ../../ run
-    background: true

--- a/testing/e2e/00-install-ceph.yaml
+++ b/testing/e2e/00-install-ceph.yaml
@@ -1,0 +1,6 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - command: make -C ../../ setup-dev-env 
+  - command: make -C ../../ run
+    background: true

--- a/testing/e2e/00-install-resource-quota.yaml
+++ b/testing/e2e/00-install-resource-quota.yaml
@@ -1,0 +1,14 @@
+apiVersion: quota.openshift.io/v1
+kind: ClusterResourceQuota
+metadata:
+  name: myteam
+spec:
+  quota:
+    hard:
+      s3/objects: 5k
+      s3/size: 5k
+      s3/buckets: 5k
+  selector:
+    labels:
+      matchLabels:
+        snappcloud.io/team: myteam

--- a/testing/e2e/01-assert.yaml
+++ b/testing/e2e/01-assert.yaml
@@ -2,20 +2,26 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3UserClaim
 metadata:
   name: s3userclaim-sample
+  namespace: s3-test
 status:
   quota:
-    maxSize: 1k
-    maxObjects: 1k
+    maxSize: "100"
+    maxObjects: "100"
     maxBuckets: 5
 
-# ---
+---
 
-# apiVersion: s3.snappcloud.io/v1alpha1
-# kind: S3User
-# metadata:
-#   name: s3-test.s3userclaim-sample
-# spec:
-#   quota:
-#     maxSize: 1k
-#     maxObjects: 1k
-#     maxBuckets: 5
+apiVersion: s3.snappcloud.io/v1alpha1
+kind: S3User
+metadata:
+  name: s3-test.s3userclaim-sample
+spec:
+  quota:
+    maxSize: "100"
+    maxObjects: "100"
+    maxBuckets: 5
+  claimRef:
+    apiVersion: s3.snappcloud.io/v1alpha1
+    kind: S3UserClaim
+    name: s3userclaim-sample
+    namespace: s3-test

--- a/testing/e2e/01-assert.yaml
+++ b/testing/e2e/01-assert.yaml
@@ -1,0 +1,21 @@
+apiVersion: s3.snappcloud.io/v1alpha1
+kind: S3UserClaim
+metadata:
+  name: s3userclaim-sample
+status:
+  quota:
+    maxSize: 1k
+    maxObjects: 1k
+    maxBuckets: 5
+
+# ---
+
+# apiVersion: s3.snappcloud.io/v1alpha1
+# kind: S3User
+# metadata:
+#   name: s3-test.s3userclaim-sample
+# spec:
+#   quota:
+#     maxSize: 1k
+#     maxObjects: 1k
+#     maxBuckets: 5

--- a/testing/e2e/01-install-userclaim.yaml
+++ b/testing/e2e/01-install-userclaim.yaml
@@ -2,11 +2,12 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3UserClaim
 metadata:
   name: s3userclaim-sample
+  namespace: s3-test
 spec:
   s3UserClass: ceph-default
   readonlySecret: s3-sample-readonly-secret
   adminSecret: s3-sample-admin-secret
   quota:
-    maxSize: 1000
-    maxObjects: 1000
+    maxSize: 100
+    maxObjects: 100
     maxBuckets: 5

--- a/testing/e2e/01-install-userclaim.yaml
+++ b/testing/e2e/01-install-userclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: s3.snappcloud.io/v1alpha1
+kind: S3UserClaim
+metadata:
+  name: s3userclaim-sample
+spec:
+  s3UserClass: ceph-default
+  readonlySecret: s3-sample-readonly-secret
+  adminSecret: s3-sample-admin-secret
+  quota:
+    maxSize: 1000
+    maxObjects: 1000
+    maxBuckets: 5

--- a/testing/e2e/02-delete-userclaim.yaml
+++ b/testing/e2e/02-delete-userclaim.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: s3.snappcloud.io/v1alpha1
+    kind: S3UserClaim
+    name: s3userclaim-sample
+    namespace: s3-test

--- a/testing/e2e/02-errors.yaml
+++ b/testing/e2e/02-errors.yaml
@@ -1,0 +1,12 @@
+apiVersion: s3.snappcloud.io/v1alpha1
+kind: S3UserClaim
+metadata:
+  name: s3userclaim-sample
+  namespace: s3-test
+
+---
+apiVersion: s3.snappcloud.io/v1alpha1
+kind: S3User
+metadata:
+  name: s3-test.s3userclaim-sample
+


### PR DESCRIPTION
This PR aims to add the end-to-end test to the operator. It uses [KUTTL](https://kuttl.dev) as the test framework.

Changes:
- KUTTL test steps have been added to the `testing/e2e` folder.
- kuttl-test.yaml provides the KUTTL test suite.
An additional step for killing the main process (the process after running `make run`) is added to the `teardown-dev-env` target in the makefile.
An additional job is added to the GitHub action for running the e2e tests.

## E2E Test Workflow
1. KUTTL creates a KIND cluster
2. Applies external crds.
3. Runs `make setup-dev-env`
4. Runs `make run`
5. Asserts the s3userclaim and s3user CRs.

## Considerations
This PR runs the operator and Ceph cluster locally. However, it's preferred to run both of them on the KIND cluster as POD and assert their container is running correctly.