### PR TITLE
[Fix]: Update cluster resource quota to support namespaces

### DIFF
--- a/internal/controllers/s3userclaim/handler.go
+++ b/internal/controllers/s3userclaim/handler.go
@@ -57,7 +57,7 @@ type Reconciler struct {
 	readonlyCephUserId        string
 	readonlyCephUserFullId    string
 	desiredSubusersStringList []string
-
+	namespaceUsedQuota        *s3v1alpha1.UserQuota
 	// configurations
 	clusterName  string
 	rgwAccessKey string

--- a/internal/controllers/s3userclaim/provisioner.go
+++ b/internal/controllers/s3userclaim/provisioner.go
@@ -350,8 +350,8 @@ func (r *Reconciler) updateClusterQuotaStatus(ctx context.Context, addCurrentQuo
 
 func (r *Reconciler) assignNamespaceQuotatoResourceStatus(statusNamespaces openshiftquota.ResourceQuotasStatusByNamespace) openshiftquota.ResourceQuotasStatusByNamespace {
 	if r.namespaceUsedQuota == nil {
-		r.logger.Error(consts.ErrNamespaceQuotaNotDefined,
-			"unable to update namespace status of cluster resource quota", "namespace", r.s3UserClaimNamespace)
+		r.logger.Info("Warning: unable to find the namespace used quota while updating the cluster resource quota",
+			"namespace", r.s3UserClaimNamespace)
 		r.namespaceUsedQuota = &s3v1alpha1.UserQuota{}
 	}
 	// update the namespace status in cluster resource quota if it's there

--- a/internal/controllers/s3userclaim/provisioner.go
+++ b/internal/controllers/s3userclaim/provisioner.go
@@ -331,7 +331,7 @@ func (r *Reconciler) updateClusterQuotaStatus(ctx context.Context, addCurrentQuo
 	assignUsedQuotaToResourceStatus(&status.Total, totalClusterUsedQuota)
 
 	// update namespace field of the status
-	status.Namespaces = r.assignNamespaceQuotatoResourceStatus(status.Namespaces)
+	status.Namespaces = r.assignNamespaceQuotaToResourceStatus(status.Namespaces)
 
 	if !apiequality.Semantic.DeepEqual(clusterQuota.Status, *status) {
 		clusterQuota.Status = *status
@@ -348,7 +348,7 @@ func (r *Reconciler) updateClusterQuotaStatus(ctx context.Context, addCurrentQuo
 	return subreconciler.ContinueReconciling()
 }
 
-func (r *Reconciler) assignNamespaceQuotatoResourceStatus(statusNamespaces openshiftquota.ResourceQuotasStatusByNamespace) openshiftquota.ResourceQuotasStatusByNamespace {
+func (r *Reconciler) assignNamespaceQuotaToResourceStatus(statusNamespaces openshiftquota.ResourceQuotasStatusByNamespace) openshiftquota.ResourceQuotasStatusByNamespace {
 	if r.namespaceUsedQuota == nil {
 		r.logger.Info("Warning: unable to find the namespace used quota while updating the cluster resource quota",
 			"namespace", r.s3UserClaimNamespace)

--- a/internal/controllers/s3userclaim/provisioner.go
+++ b/internal/controllers/s3userclaim/provisioner.go
@@ -262,8 +262,9 @@ func (r *Reconciler) updateNamespaceQuotaStatusExclusive(ctx context.Context) (*
 }
 
 func (r *Reconciler) updateNamespaceQuotaStatus(ctx context.Context, addCurrentQuota bool) (*ctrl.Result, error) {
+	var err error
 	// sum up all quotas in the namespace
-	totalUsedQuota, err := s3v1alpha1.CalculateNamespaceUsedQuota(ctx, r.uncachedReader, r.s3UserClaim, addCurrentQuota)
+	r.namespaceUsedQuota, err = s3v1alpha1.CalculateNamespaceUsedQuota(ctx, r.uncachedReader, r.s3UserClaim, addCurrentQuota)
 	if err != nil {
 		r.logger.Error(err, "failed to calculate namespace used quota")
 		return subreconciler.Requeue()
@@ -280,9 +281,8 @@ func (r *Reconciler) updateNamespaceQuotaStatus(ctx context.Context, addCurrentQ
 		if status.Used == nil {
 			status.Used = corev1.ResourceList{}
 		}
-		status.Used[consts.ResourceNameS3MaxObjects] = totalUsedQuota.MaxObjects
-		status.Used[consts.ResourceNameS3MaxSize] = totalUsedQuota.MaxSize
-		status.Used[consts.ResourceNameS3MaxBuckets] = *resource.NewQuantity(totalUsedQuota.MaxBuckets, resource.DecimalSI)
+		assignUsedQuotaToResourceStatus(status, r.namespaceUsedQuota)
+
 		if !apiequality.Semantic.DeepEqual(quota.Status, *status) {
 			quota.Status = *status
 			if err := r.Status().Update(ctx, &quota); err != nil {
@@ -323,14 +323,16 @@ func (r *Reconciler) updateClusterQuotaStatus(ctx context.Context, addCurrentQuo
 		r.logger.Error(err, "failed to get clusterQuota")
 		return subreconciler.Requeue()
 	}
-
 	status := clusterQuota.Status.DeepCopy()
 	if status.Total.Used == nil {
 		status.Total.Used = corev1.ResourceList{}
 	}
-	status.Total.Used[consts.ResourceNameS3MaxObjects] = totalClusterUsedQuota.MaxObjects
-	status.Total.Used[consts.ResourceNameS3MaxSize] = totalClusterUsedQuota.MaxSize
-	status.Total.Used[consts.ResourceNameS3MaxBuckets] = *resource.NewQuantity(totalClusterUsedQuota.MaxBuckets, resource.DecimalSI)
+	// update total field of the status
+	assignUsedQuotaToResourceStatus(&status.Total, totalClusterUsedQuota)
+
+	// update namespace field of the status
+	status.Namespaces = r.assignNamespaceQuotatoResourceStatus(status.Namespaces)
+
 	if !apiequality.Semantic.DeepEqual(clusterQuota.Status, *status) {
 		clusterQuota.Status = *status
 		if err := r.Status().Update(ctx, clusterQuota); err != nil {
@@ -345,6 +347,38 @@ func (r *Reconciler) updateClusterQuotaStatus(ctx context.Context, addCurrentQuo
 
 	return subreconciler.ContinueReconciling()
 }
+
+func (r *Reconciler) assignNamespaceQuotatoResourceStatus(statusNamespaces openshiftquota.ResourceQuotasStatusByNamespace) openshiftquota.ResourceQuotasStatusByNamespace {
+	if r.namespaceUsedQuota == nil {
+		r.logger.Error(consts.ErrNamespaceQuotaNotDefined,
+			"unable to update namespace status of cluster resource quota", "namespace", r.s3UserClaimNamespace)
+		r.namespaceUsedQuota = &s3v1alpha1.UserQuota{}
+	}
+	// update the namespace status in cluster resource quota if it's there
+	for i, namespaceQuota := range statusNamespaces {
+		if namespaceQuota.Namespace == r.s3UserClaimNamespace {
+			assignUsedQuotaToResourceStatus(&statusNamespaces[i].Status, r.namespaceUsedQuota)
+			return statusNamespaces
+		}
+	}
+	// create a new item for the current namespace if it's not already there
+	namepaceQuotaStatus := corev1.ResourceQuotaStatus{}
+	assignUsedQuotaToResourceStatus(&namepaceQuotaStatus, r.namespaceUsedQuota)
+	namespaceQuota := openshiftquota.ResourceQuotaStatusByNamespace{Namespace: r.s3UserClaimNamespace,
+		Status: namepaceQuotaStatus}
+	statusNamespaces = append(statusNamespaces, namespaceQuota)
+	return statusNamespaces
+}
+
+func assignUsedQuotaToResourceStatus(resourceQuotaStatus *corev1.ResourceQuotaStatus, usedQuota *s3v1alpha1.UserQuota) {
+	if resourceQuotaStatus.Used == nil {
+		resourceQuotaStatus.Used = corev1.ResourceList{}
+	}
+	resourceQuotaStatus.Used[consts.ResourceNameS3MaxObjects] = usedQuota.MaxObjects
+	resourceQuotaStatus.Used[consts.ResourceNameS3MaxSize] = usedQuota.MaxSize
+	resourceQuotaStatus.Used[consts.ResourceNameS3MaxBuckets] = *resource.NewQuantity(usedQuota.MaxBuckets, resource.DecimalSI)
+}
+
 func (r *Reconciler) addCleanupFinalizer(ctx context.Context) (*ctrl.Result, error) {
 	if objUpdated := controllerutil.AddFinalizer(r.s3UserClaim, consts.S3UserClaimCleanupFinalizer); objUpdated {
 		if err := r.Update(ctx, r.s3UserClaim); err != nil {

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -23,7 +23,6 @@ const (
 	ErrExceededClusterQuota        = CustomError("exceeded cluster quota")
 	ErrExceededNamespaceQuota      = CustomError("exceeded namespace quota")
 	ErrClusterQuotaNotDefined      = CustomError("cluster quota is not defined")
-	ErrNamespaceQuotaNotDefined    = CustomError("namespace quota is not defined")
 	S3UserClassImmutableErrMessage = "s3UserClass is immutable"
 	S3UserRefImmutableErrMessage   = "s3UserRef is immutable"
 	S3UserRefNotFoundErrMessage    = "There is no s3UserClaim regarding the defined s3UserRef"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -23,6 +23,7 @@ const (
 	ErrExceededClusterQuota        = CustomError("exceeded cluster quota")
 	ErrExceededNamespaceQuota      = CustomError("exceeded namespace quota")
 	ErrClusterQuotaNotDefined      = CustomError("cluster quota is not defined")
+	ErrNamespaceQuotaNotDefined    = CustomError("namespace quota is not defined")
 	S3UserClassImmutableErrMessage = "s3UserClass is immutable"
 	S3UserRefImmutableErrMessage   = "s3UserRef is immutable"
 	S3UserRefNotFoundErrMessage    = "There is no s3UserClaim regarding the defined s3UserRef"

--- a/testing/e2e/01-install-ceph-operator.yaml
+++ b/testing/e2e/01-install-ceph-operator.yaml
@@ -5,6 +5,8 @@ commands:
   - command: kubectl apply -f ../../config/external-crd
   - command: kubectl create namespace s3-test
     ignoreFailure: true
+  - command: kubectl create namespace s3-test2
+    ignoreFailure: true
   # Create namespace s3-operator-system
   - command: kubectl create namespace s3-operator-system
     ignoreFailure: true
@@ -14,3 +16,4 @@ commands:
   - command: make -C ../../ deploy-for-e2e-test IMG=s3-operator:latest
   # The namespace should have the team label for the cluster resource quota
   - command: kubectl label namespace s3-test snappcloud.io/team=myteam
+  - command: kubectl label namespace s3-test2 snappcloud.io/team=myteam

--- a/testing/e2e/02-assert.yaml
+++ b/testing/e2e/02-assert.yaml
@@ -62,7 +62,7 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3UserClaim
 metadata:
   name: s3userclaim-extra
-  namespace: s3-test
+  namespace: s3-test2
 status:
   quota:
     maxSize: 5k
@@ -74,7 +74,7 @@ status:
 apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3User
 metadata:
-  name: s3-test.s3userclaim-extra
+  name: s3-test2.s3userclaim-extra
 spec:
   quota:
     maxSize: 5k
@@ -84,14 +84,14 @@ spec:
     apiVersion: s3.snappcloud.io/v1alpha1
     kind: S3UserClaim
     name: s3userclaim-extra
-    namespace: s3-test
+    namespace: s3-test2
 
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: s3-extra-admin-secret
-  namespace: s3-test
+  namespace: s3-test2
   ownerReferences:
   - apiVersion: s3.snappcloud.io/v1alpha1
     blockOwnerDeletion: true
@@ -105,7 +105,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: s3-extra-readonly-secret
-  namespace: s3-test
+  namespace: s3-test2
   ownerReferences:
   - apiVersion: s3.snappcloud.io/v1alpha1
     blockOwnerDeletion: true
@@ -126,9 +126,9 @@ status:
     s3/objects: 1k
     s3/size: 20k
   used:
-    s3/buckets: "10"
-    s3/objects: 1k
-    s3/size: 15k
+    s3/buckets: "5"
+    s3/objects: "500"
+    s3/size: 10k
 
 ---
 apiVersion: quota.openshift.io/v1
@@ -141,3 +141,17 @@ status:
       s3/buckets: "10"
       s3/objects: 1k
       s3/size: 15k
+  namespaces:
+    - namespace: s3-test
+      status:
+        used:
+          s3/buckets: "5"
+          s3/objects: "500"
+          s3/size: 10k
+    - namespace: s3-test2
+      status:
+        used:
+          s3/buckets: "5"
+          s3/objects: "500"
+          s3/size: 5k
+

--- a/testing/e2e/02-create-userclaim.yaml
+++ b/testing/e2e/02-create-userclaim.yaml
@@ -18,7 +18,7 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3UserClaim
 metadata:
   name: s3userclaim-extra
-  namespace: s3-test
+  namespace: s3-test2
 spec:
   s3UserClass: ceph-default
   readonlySecret: s3-extra-readonly-secret

--- a/testing/e2e/03-assert.yaml
+++ b/testing/e2e/03-assert.yaml
@@ -44,6 +44,6 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3Bucket
 metadata:
   name: s3bucket-extra-delete
-  namespace: s3-test
+  namespace: s3-test2
 status:
   created: true

--- a/testing/e2e/03-create-bucket.yaml
+++ b/testing/e2e/03-create-bucket.yaml
@@ -25,7 +25,7 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3Bucket
 metadata:
   name: s3bucket-extra-delete
-  namespace: s3-test
+  namespace: s3-test2
 spec:
   s3UserRef: s3userclaim-extra
   s3DeletionPolicy: delete

--- a/testing/e2e/10-assert.yaml
+++ b/testing/e2e/10-assert.yaml
@@ -19,6 +19,19 @@ kind: ClusterResourceQuota
 metadata:
   name: myteam
 status:
+  namespaces:
+  - namespace: s3-test
+    status:
+      used:
+        s3/buckets: "0"
+        s3/objects: "0"
+        s3/size: "0"
+  - namespace: s3-test2
+    status:
+      used:
+        s3/buckets: "0"
+        s3/objects: "0"
+        s3/size: "0"
   total:
     used:
       s3/buckets: "0"

--- a/testing/e2e/10-delete-extra-user-bucket.yaml
+++ b/testing/e2e/10-delete-extra-user-bucket.yaml
@@ -1,5 +1,5 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestStep
 commands:
-  - command: kubectl delete s3bucket s3bucket-extra-delete -n s3-test
-  - command: kubectl delete s3userclaim s3userclaim-extra -n s3-test
+  - command: kubectl delete s3bucket s3bucket-extra-delete -n s3-test2
+  - command: kubectl delete s3userclaim s3userclaim-extra -n s3-test2

--- a/testing/e2e/10-errors.yaml
+++ b/testing/e2e/10-errors.yaml
@@ -2,7 +2,7 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3Bucket
 metadata:
   name: s3bucket-extra-delete
-  namespace: s3-test
+  namespace: s3-test2
 
 ---
 
@@ -10,10 +10,10 @@ apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3UserClaim
 metadata:
   name: s3userclaim-extra
-  namespace: s3-test
+  namespace: s3-test2
 
 ---
 apiVersion: s3.snappcloud.io/v1alpha1
 kind: S3User
 metadata:
-  name: s3-test.s3userclaim-extra
+  name: s3-test2.s3userclaim-extra


### PR DESCRIPTION
Cluster resource quota status has two fields: `total` and `namespaces`. The namespaces field is a slice of the namespaces matching the cluster resource quota selector. 
At the moment, the operator only updates the `total` field. Hence, the `applied resource quota`, which mirrors the `cluster resource quota` for the current namespace, doesn't have the namespace status and shows an error in the OKD console.

This PR adds the appropriate update, adding the namespace quota to the cluster resource quota status.
Additionally, I have put the code lines for assigning usedQuota needed for the `total` field in a separate function, `assignUsedQuotaToResourceStatus`.