### PR TITLE
Fix/same secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,8 +24,9 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
-
+.vscode
 vendor/
+
 # Downloaded go release for building testing Dockerfile
 testing/go*.tar.gz
 # Container id files of dev env containers

--- a/api/v1alpha1/s3userclaim_webhook.go
+++ b/api/v1alpha1/s3userclaim_webhook.go
@@ -248,12 +248,11 @@ func validateSecrets(secretNames []string, namespace string, allErrs field.Error
 		case apierrors.IsNotFound(err):
 			continue
 		case err != nil:
-			allErrs = append(allErrs, field.InternalError(field.NewPath("spec").Child(secretName), err))
-			continue
+			allErrs = append(allErrs,
+				field.InternalError(field.NewPath("spec"), fmt.Errorf("error with getting secret '%s': %w", secretName, err)))
 		default:
 			allErrs = append(allErrs,
-				field.Forbidden(field.NewPath("spec").Child(secretName), consts.SecretExistsErrMessage))
-			continue
+				field.Forbidden(field.NewPath("spec"), fmt.Sprintf("secret %s exists", secretName)))
 		}
 	}
 	return allErrs

--- a/internal/controllers/s3userclaim/provisioner.go
+++ b/internal/controllers/s3userclaim/provisioner.go
@@ -327,7 +327,8 @@ func (r *Reconciler) ensureSecret(ctx context.Context, secret *corev1.Secret) (*
 			!metav1.IsControlledBy(existingSecret, r.s3UserClaim) {
 			existingSecret.Data = secret.Data
 			if err := ctrl.SetControllerReference(r.s3UserClaim, existingSecret, r.scheme); err != nil {
-				return nil, err
+				r.logger.Error(err, "failed to set controller reference", "secret name", secret.Name)
+				return subreconciler.Requeue()
 			}
 			if err := r.Update(ctx, existingSecret); err != nil {
 				r.logger.Error(err, "failed to update secret", "name", secret.Name)

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -27,7 +27,6 @@ const (
 	S3UserRefImmutableErrMessage   = "s3UserRef is immutable"
 	S3UserRefNotFoundErrMessage    = "there is no s3UserClaim regarding the defined s3UserRef"
 	ContactCloudTeamErrMessage     = "please contact the cloud team"
-	SecretExistsErrMessage         = "the secret exists"
 
 	FinalizerPrefix             = "s3.snappcloud.io/"
 	S3UserClaimCleanupFinalizer = FinalizerPrefix + "cleanup-s3userclaim"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -25,8 +25,9 @@ const (
 	ErrClusterQuotaNotDefined      = CustomError("cluster quota is not defined")
 	S3UserClassImmutableErrMessage = "s3UserClass is immutable"
 	S3UserRefImmutableErrMessage   = "s3UserRef is immutable"
-	S3UserRefNotFoundErrMessage    = "There is no s3UserClaim regarding the defined s3UserRef"
+	S3UserRefNotFoundErrMessage    = "there is no s3UserClaim regarding the defined s3UserRef"
 	ContactCloudTeamErrMessage     = "please contact the cloud team"
+	SecretExistsErrMessage         = "the secret exists"
 
 	FinalizerPrefix             = "s3.snappcloud.io/"
 	S3UserClaimCleanupFinalizer = FinalizerPrefix + "cleanup-s3userclaim"

--- a/testing/e2e/04-validation-webhook.yaml
+++ b/testing/e2e/04-validation-webhook.yaml
@@ -5,6 +5,10 @@ commands:
     ignoreFailure: true
   - command: kubectl apply -f s3bucket-wrong-s3userref.yaml
     ignoreFailure: true
+  - command: kubectl apply -f create-s3user-with-existing-secret.yaml
+    ignoreFailure: true
+  - command: kubectl apply -f update-s3user-with-existing-secret.yaml
+    ignoreFailure: true
   - command: kubectl delete s3userclaim s3userclaim-sample -n s3-test
     ignoreFailure: true
 assert:
@@ -12,3 +16,4 @@ assert:
   - 02-assert.yaml
 error:
   - s3bucket-wrong-s3userref.yaml
+  - create-s3user-with-existing-secret.yaml

--- a/testing/e2e/04-validation-webhook.yaml
+++ b/testing/e2e/04-validation-webhook.yaml
@@ -7,8 +7,6 @@ commands:
     ignoreFailure: true
   - command: kubectl apply -f create-s3user-with-existing-secret.yaml
     ignoreFailure: true
-  - command: kubectl apply -f update-s3user-with-existing-secret.yaml
-    ignoreFailure: true
   - command: kubectl delete s3userclaim s3userclaim-sample -n s3-test
     ignoreFailure: true
 assert:

--- a/testing/e2e/create-s3user-with-existing-secret.yaml
+++ b/testing/e2e/create-s3user-with-existing-secret.yaml
@@ -1,0 +1,16 @@
+# Creating s3userclaim with existing secrets must be deined
+apiVersion: s3.snappcloud.io/v1alpha1
+kind: S3UserClaim
+metadata:
+  name: s3userclaim-sample2
+  namespace: s3-test
+spec:
+  s3UserClass: ceph-default
+  # existing secrets
+  readonlySecret: s3-sample-readonly-secret
+  adminSecret: s3-sample-admin-secret
+  quota:
+    maxSize: 100
+    maxObjects: 50
+    maxBuckets: 5
+


### PR DESCRIPTION
The operator would face panic when a `s3userclaim` with already existing secrets was created. 
This PR:
- Fixes the subrecociler behavior while facing an error on setting controller reference in ensuring secrets to prevent panics.
- Creates validation webhooks on create/update events that deny requests with existing secrets.
- Updates the e2e test phase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude `.vscode` directory and clarify ignored items.

- **New Features**
  - Implemented secret name validation for `S3UserClaim` creation and updates.

- **Bug Fixes**
  - Improved error handling in secret provisioning to ensure proper requeuing.

- **Documentation**
  - Standardized error messages for consistency in user communication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->